### PR TITLE
Sub: 계정 - 내 계정 테이블 완료

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
 {
   "semi": true,
   "tabWidth": 2,
-  "printWidth": 120,
+  "printWidth": 80,
   "singleQuote": true,
   "trailingComma": "all",
   "useTabs": false,

--- a/src/components/ui/CheckBox.tsx
+++ b/src/components/ui/CheckBox.tsx
@@ -1,4 +1,5 @@
 import { CheckBoxSelected } from '@/assets/images';
+import { ChangeEventHandler } from 'react';
 import styled, { css } from 'styled-components';
 
 const Wrap = styled.div`
@@ -54,17 +55,34 @@ const CheckInput = styled.input<{ disabled: boolean; small?: boolean }>`
   }
 `;
 
-interface CheckBoxProps extends React.InputHTMLAttributes<HTMLInputElement> {
-  id: string;
+export interface CheckedValue {
+  id: string | number;
+  checked: boolean;
+}
+
+interface CheckBoxProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'id'> {
+  id: string | number;
+  onChange?: (checkedValue: CheckedValue) => void;
   label?: string | React.ReactNode;
   small?: boolean;
 }
 
-export const CheckBox = ({ id, label, small, disabled = false, ...props }: CheckBoxProps) => {
+export const CheckBox = ({ id, label, small, disabled = false, onChange, ...props }: CheckBoxProps) => {
+  const handleChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    onChange?.({ id: e.target.id, checked: e.target.checked });
+  };
+
   return (
     <Wrap>
-      <CheckInput {...props} id={id} type="checkbox" disabled={disabled} small={small} />
-      <label htmlFor={id}>{label}</label>
+      <CheckInput
+        {...props}
+        id={String(id)}
+        onChange={handleChange}
+        type="checkbox"
+        disabled={disabled}
+        small={small}
+      />
+      <label htmlFor={String(id)}>{label}</label>
     </Wrap>
   );
 };

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,5 +1,11 @@
 // TODO: 상태에 따라 컴포넌트 의존 낮추기 ex) single, multi, inputMode - chkim
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   default as ReactSelect,
   DropdownIndicatorProps,
@@ -14,13 +20,18 @@ import styled from 'styled-components';
 import { Close, Dropdown } from '@/assets/images';
 import { theme } from '@/styles';
 
-function getSelectValue(value?: ValueType, options?: SelectOption[]): OptionType {
+function getSelectValue(
+  value?: ValueType,
+  options?: SelectOption[],
+): OptionType {
   if (!value) {
     return [];
   }
 
   if (Array.isArray(value)) {
-    return options?.filter((option) => value.includes(option.value)) as OptionType;
+    return options?.filter((option) =>
+      value.includes(option.value),
+    ) as OptionType;
   }
 
   return options?.find((option) => option.value === value) as OptionType;
@@ -49,9 +60,12 @@ interface SelectOption {
 }
 export type OptionType = MultiValue<SelectOption> | SingleValue<SelectOption>;
 type ValueType = string | Array<string>;
-export type SelectChangeOptionType<T = any> = T extends Array<string> ? T : string;
+export type SelectChangeOptionType<T = any> = T extends Array<string>
+  ? T
+  : string;
 
-interface SelectProps extends Omit<Props<SelectOption>, 'value' | 'onInputChange' | 'onChange'> {
+interface SelectProps
+  extends Omit<Props<SelectOption>, 'value' | 'onInputChange' | 'onChange'> {
   /**
    * Select의 크기를 조정한다.
    */
@@ -87,14 +101,18 @@ export const Select = ({
   onChange: onChangeExternal,
   ...props
 }: SelectProps) => {
-  const [selectValue, setSelectValue] = useState<OptionType>(() => getSelectValue(value, options as SelectOption[]));
+  const [selectValue, setSelectValue] = useState<OptionType>(() =>
+    getSelectValue(value, options as SelectOption[]),
+  );
 
   const onChange = useRef(onChangeExternal);
 
   const handleOptionChange = (option: OptionType) => {
     setSelectValue(option);
 
-    const value = (option as SelectOption).value || (option as SelectOption[]).map((optionItem) => optionItem.value);
+    const value =
+      (option as SelectOption).value ||
+      (option as SelectOption[]).map((optionItem) => optionItem.value);
 
     onChange.current?.(value, option);
   };
@@ -130,7 +148,10 @@ export const Select = ({
               return prev;
             }
 
-            const newInputValues = [...prev, { value: inputValue, label: inputValue }];
+            const newInputValues = [
+              ...prev,
+              { value: inputValue, label: inputValue },
+            ];
 
             return newInputValues;
           });
@@ -160,13 +181,19 @@ export const Select = ({
       control: (provided, state) => ({
         ...provided,
         borderRadius: '4px',
-        backgroundColor: state.isDisabled ? theme.colors.gray1 : theme.colors.white,
+        backgroundColor: state.isDisabled
+          ? theme.colors.gray1
+          : theme.colors.white,
         color: state.isDisabled ? theme.colors.gray2 : theme.colors.white,
-        borderColor: state.isFocused ? theme.colors.primary : theme.colors.gray2,
+        borderColor: state.isFocused
+          ? theme.colors.primary
+          : theme.colors.gray2,
         boxShadow: 'none',
         cursor: inputMode ? 'text' : 'pointer',
         '&:hover': {
-          borderColor: state.isFocused ? theme.colors.primary : theme.colors.gray2,
+          borderColor: state.isFocused
+            ? theme.colors.primary
+            : theme.colors.gray2,
         },
       }),
       valueContainer: (provided, state) => ({
@@ -249,7 +276,9 @@ export const Select = ({
           ? theme.colors.gray2
           : theme.colors.white,
         '&:hover': {
-          backgroundColor: state.isSelected ? theme.colors.gray2 : theme.colors.gray1,
+          backgroundColor: state.isSelected
+            ? theme.colors.gray2
+            : theme.colors.gray1,
         },
       }),
       indicatorSeparator: () => ({
@@ -259,11 +288,16 @@ export const Select = ({
     [inputMode, width],
   );
 
-  const MultiValueRemove = ({ innerProps, data }: MultiValueRemoveProps<SelectOption>) => {
+  const MultiValueRemove = ({
+    innerProps,
+    data,
+  }: MultiValueRemoveProps<SelectOption>) => {
     const handleClick: React.MouseEventHandler<HTMLDivElement> = (e) => {
       if (inputMode) {
         return setInputValues((prev) => {
-          const newInputValues = prev.filter((option) => option.value !== data.value);
+          const newInputValues = prev.filter(
+            (option) => option.value !== data.value,
+          );
 
           onChange.current?.(
             newInputValues.map((option) => option.value),
@@ -283,7 +317,9 @@ export const Select = ({
     );
   };
 
-  const DropdownIndicator = ({ selectProps }: DropdownIndicatorProps<SelectOption>) => {
+  const DropdownIndicator = ({
+    selectProps,
+  }: DropdownIndicatorProps<SelectOption>) => {
     if (!showDropDownIcon || inputMode) {
       return null;
     }
@@ -298,6 +334,7 @@ export const Select = ({
   return (
     <ReactSelect
       {...props}
+      classNamePrefix="apro"
       styles={styles}
       inputValue={inputValue}
       value={inputMode ? inputValues : selectValue}

--- a/src/components/ui/Table.tsx
+++ b/src/components/ui/Table.tsx
@@ -1,0 +1,70 @@
+import styled from 'styled-components';
+import { default as RcTable } from 'rc-table';
+import { TableProps } from 'rc-table/lib/Table';
+import 'rc-table/assets/index.css';
+
+const TableStyled = styled(RcTable)<any>`
+  color: ${({ theme }) => theme.colors.black};
+  background-color: ${({ theme }) => theme.colors.white};
+
+  & .rc-table-content {
+    border: none;
+  }
+
+  & .rc-table-thead {
+    font-weight: 500;
+    font-size: 16px;
+    color: ${({ theme }) => theme.colors.gray3};
+    border-bottom: 1px solid ${({ theme }) => theme.colors.gray2};
+    th.rc-table-cell {
+      border: none;
+      text-align: left;
+      line-height: 24px;
+      padding: 8px 18px;
+      background-color: ${({ theme }) => theme.colors.white};
+    }
+  }
+
+  & .rc-table-tbody {
+    tr.rc-table-row {
+      border-bottom: 1px solid ${({ theme }) => theme.colors.gray1};
+
+      &:nth-last-of-type(1) {
+        border: none;
+      }
+
+      td.rc-table-cell {
+        border: none;
+        vertical-align: middle;
+        padding: 18px;
+        line-height: 24px;
+        font-weight: 500;
+        font-size: 16px;
+
+        &.rc-table-cell-row-hover {
+          background-color: transparent;
+        }
+      }
+    }
+
+    /* Empty */
+    tr.rc-table-placeholder {
+      border-top: none;
+      border: 1px solid ${({ theme }) => theme.colors.gray1};
+      border-radius: 6px;
+
+      td {
+        text-align: center;
+        vertical-align: middle;
+        border: none;
+        font-size: 14px;
+        line-height: 22px;
+        height: 180px;
+      }
+    }
+  }
+`;
+
+export const Table = <T,>(props: TableProps<T>) => {
+  return <TableStyled {...props} />;
+};

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -8,3 +8,4 @@ export * from './Modal';
 export * from './Select';
 export * from './SolidButton';
 export * from './Title';
+export * from './Table';

--- a/src/components/ui/stories/Table.stories.tsx
+++ b/src/components/ui/stories/Table.stories.tsx
@@ -1,0 +1,66 @@
+/* eslint-disable no-alert */
+import { ComponentProps } from 'react';
+import { ComponentStory, ComponentMeta, ArgTypes } from '@storybook/react';
+import { Table } from '../Table';
+
+type MyArgTypes = Partial<
+  Record<keyof ComponentProps<typeof Table>, ArgTypes[string]>
+>;
+const argTypes: MyArgTypes = {};
+
+export default {
+  title: 'components/Table',
+  components: Table,
+  argTypes,
+} as ComponentMeta<typeof Table>;
+
+const data = [
+  {
+    id: 1,
+    tools: 'notion',
+    account: 'cskim132@gmail.com',
+  },
+  {
+    id: 2,
+    tools: 'slack',
+    account: 'cskim132@gmail.com',
+  },
+  {
+    id: 3,
+    tools: 'notion',
+    account: 'cskim132@gmail.com',
+  },
+];
+
+const Template: ComponentStory<typeof Table> = ({ ...props }) => {
+  const columns = [
+    {
+      title: '아이디',
+      dataIndex: 'id',
+      key: 'id',
+    },
+    {
+      title: '협업툴',
+      dataIndex: 'tools',
+      key: 'tools',
+    },
+    {
+      title: '계정',
+      dataIndex: 'account',
+      key: 'account',
+    },
+  ];
+
+  return <Table {...props} columns={columns}></Table>;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  data,
+};
+
+export const Empty = Template.bind({});
+Empty.args = {
+  data: [],
+  emptyText: '계정 정보가 없습니다.',
+};

--- a/src/features/collaboration/_fixtures/account_list.json
+++ b/src/features/collaboration/_fixtures/account_list.json
@@ -3,5 +3,20 @@
     "id": 1,
     "tools": "notion",
     "account": "cskim132@gmail.com"
+  },
+  {
+    "id": 2,
+    "tools": "slack",
+    "account": "cskim132@gmail.com"
+  },
+  {
+    "id": 3,
+    "tools": "zoom",
+    "account": "cskim132@gmail.com"
+  },
+  {
+    "id": 4,
+    "tools": "figma",
+    "account": "cskim132@gmail.com"
   }
 ]

--- a/src/features/collaboration/components/account/MyAccountTable.tsx
+++ b/src/features/collaboration/components/account/MyAccountTable.tsx
@@ -1,32 +1,31 @@
-import Table from 'rc-table';
-
-import type { ColumnType } from 'rc-table/lib/interface';
+import { ColumnsType } from 'rc-table/lib/interface';
+import styled from 'styled-components';
 import type { AccountTableModel } from '../../models/account.models';
 
-import { CheckBox } from '@/components';
+import { Table } from '@/components';
 
-const columns: ColumnType<AccountTableModel>[] = [
-  {
-    title: <CheckBox id="all" />,
-    dataIndex: 'id',
-    key: 'id',
-    render: (id: number) => <CheckBox id={id.toString()} />,
-  },
-  {
-    title: '협업툴',
-    dataIndex: 'tools',
-    key: 'tools',
-  },
-  {
-    title: '계정',
-    dataIndex: 'account',
-    key: 'account',
-  },
-];
+const Wrap = styled.div`
+  border: 1px solid ${({ theme }) => theme.colors.gray1};
+  padding: 12px;
+  border-radius: 6px;
+`;
+
 interface MyAccountTableProps {
+  columns: ColumnsType<AccountTableModel>;
   tableData: AccountTableModel[];
 }
 
-export const MyAccountTable = ({ tableData = [] }: MyAccountTableProps) => {
-  return <Table columns={columns} data={tableData} />;
+export const MyAccountTable = ({
+  columns,
+  tableData = [],
+}: MyAccountTableProps) => {
+  return (
+    <Wrap>
+      <Table
+        emptyText="계정 정보가 없습니다."
+        columns={columns}
+        data={tableData}
+      />
+    </Wrap>
+  );
 };

--- a/src/features/collaboration/containers/account/AccountByMemberContainer.tsx
+++ b/src/features/collaboration/containers/account/AccountByMemberContainer.tsx
@@ -3,7 +3,7 @@ import { AccountByMemberTable } from '../../components/account/AccountByMemberTa
 export const AccountByMemberContainer = () => {
   return (
     <>
-      <AccountByMemberTable tableData={[]} onPageChange={() => ({})} />;
+      <AccountByMemberTable tableData={[]} onPageChange={() => ({})} />
     </>
   );
 };

--- a/src/features/collaboration/containers/account/MyAccountContainer.tsx
+++ b/src/features/collaboration/containers/account/MyAccountContainer.tsx
@@ -1,59 +1,161 @@
 import { useEffect, useMemo, useState } from 'react';
+import styled from 'styled-components';
 
-import { Title, LineButton } from '@/components';
+import { LineButton, Title } from '@/components';
 import { MyAccountTable } from '../../components/account/MyAccountTable';
-
+import { useMyAccountTableColumns } from '../../hooks/useMyAccountTableCoumns';
+import { AccountTableModel } from '../../models/account.models';
 import TABLE_DATA from '../../_fixtures/account_list.json';
 
-export const MyAccountContainer = () => {
-  const [tableData, setTableData] = useState<any[]>([]);
-  const [selectedTableData, setSelectedTableData] = useState<number[]>([]);
+const Wrap = styled.div`
+  padding-bottom: 60px;
+`;
 
-  const isEditableTable = useMemo(() => tableData.filter((table) => table.editable === true), [tableData]);
-  const isSelectedTable = useMemo(() => selectedTableData.length !== 0, [selectedTableData.length]);
+const TableOutTitleWrap = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 30px;
+`;
+
+const TableOutButtonWrap = styled.div`
+  display: flex;
+  gap: 8px;
+  font-size: 14px;
+
+  button {
+    &:nth-last-of-type(1) {
+      width: 100px;
+    }
+    width: fit-content;
+    padding: 9px 16px;
+  }
+`;
+
+export const MyAccountContainer = () => {
+  const [tableData, setTableData] = useState<AccountTableModel[]>([]);
+  const [selectedRowIds, setSelectedRowIds] = useState<number[]>([]);
+
+  const isEditableTable = useMemo(
+    () => tableData.filter((table) => table.editable === true),
+    [tableData],
+  );
+  const isSelectedTable = useMemo(
+    () => selectedRowIds.length !== 0,
+    [selectedRowIds.length],
+  );
+  const isAllSelected = useMemo(
+    () => tableData.length > 0 && tableData.length === selectedRowIds.length,
+    [selectedRowIds.length, tableData.length],
+  );
+
+  const handleDeleteClick = () => {
+    setTableData((prev) =>
+      prev.filter((item) => !selectedRowIds.includes(item.id)),
+    );
+
+    setSelectedRowIds([]);
+  };
+
+  const handleEditableClick = () => {
+    setTableData((prev) =>
+      prev.map((item) =>
+        selectedRowIds.includes(item.id) ? { ...item, editable: true } : item,
+      ),
+    );
+
+    setSelectedRowIds([]);
+  };
 
   const handleConfirmClick = () => {
-    const newTableItems = tableData.filter((table) => table.id === null);
+    const newTableItems = tableData.filter((table) => table.editable === true);
 
     // TODO: server 호출
     console.log(newTableItems);
   };
 
   const handleAddClick = () => {
-    const newTableItem = {
-      id: null,
+    const newTableItem: AccountTableModel = {
+      id: Date.now(),
+      account: '',
+      tools: 'notion',
       editable: true,
     };
 
-    setTableData((prev) => [...prev, newTableItem]);
+    setTableData((prev) => [newTableItem, ...prev]);
   };
 
-  const handleSelectClicck = (any?: any) => {
-    // TODO: select 시, 삭제, 수정 이벤트
-    setSelectedTableData(any);
+  const handleSelectRows = () => {
+    setSelectedRowIds((prev) => {
+      if (prev.length === tableData.length) {
+        return [];
+      }
+      return tableData.map((row) => row.id);
+    });
+  };
+
+  const handleSelectRow = (rowId: number) => {
+    setSelectedRowIds((prev) => {
+      if (prev.includes(rowId)) {
+        return prev.filter((item) => item !== rowId);
+      }
+
+      return [...prev, rowId];
+    });
+  };
+
+  const handleRowChange = (row: Partial<AccountTableModel>) => {
+    if (!row.id) {
+      return;
+    }
+
+    setTableData((prev) => {
+      return prev.map((item) =>
+        item.id === row.id
+          ? {
+              id: row.id,
+              account: row.account || item.account,
+              tools: row.tools || item.tools,
+              editable: row.editable,
+            }
+          : item,
+      );
+    });
   };
 
   useEffect(() => {
     setTableData(() => TABLE_DATA);
   }, []);
 
-  return (
-    <>
-      <div>
-        <Title level={2}>내 계정</Title>
-        {isSelectedTable && (
-          <div>
-            <LineButton>삭제하기</LineButton>
-            <LineButton>수정하기</LineButton>
-          </div>
-        )}
-        {isEditableTable.length && <LineButton onClick={handleConfirmClick}>완료</LineButton>}
-        <LineButton variant="primary" onClick={handleAddClick}>
-          계정 추가 +
-        </LineButton>
-      </div>
+  const columns = useMyAccountTableColumns({
+    isAllSelected,
+    selectedRowIds,
+    onRowChange: handleRowChange,
+    onSelectRow: handleSelectRow,
+    onSelectRows: handleSelectRows,
+  });
 
-      <MyAccountTable tableData={tableData} />
-    </>
+  return (
+    <Wrap>
+      <TableOutTitleWrap>
+        <Title level={2}>내 계정</Title>
+        <TableOutButtonWrap>
+          {isSelectedTable ? (
+            <>
+              <LineButton onClick={handleDeleteClick}>삭제하기</LineButton>
+              <LineButton onClick={handleEditableClick}>수정하기</LineButton>
+            </>
+          ) : null}
+          {isEditableTable.length ? (
+            <LineButton onClick={handleConfirmClick}>완료</LineButton>
+          ) : null}
+          <LineButton variant="primary" onClick={handleAddClick}>
+            계정 추가 +
+          </LineButton>
+        </TableOutButtonWrap>
+      </TableOutTitleWrap>
+
+      <MyAccountTable columns={columns} tableData={tableData} />
+    </Wrap>
   );
 };

--- a/src/features/collaboration/hooks/useMyAccountTableCoumns.tsx
+++ b/src/features/collaboration/hooks/useMyAccountTableCoumns.tsx
@@ -1,0 +1,182 @@
+import { ChangeEventHandler, useCallback, useMemo } from 'react';
+import styled from 'styled-components';
+import type { ColumnType } from 'rc-table/lib/interface';
+import type { AccountTableModel } from '../models/account.models';
+
+import { CheckBox, CheckedValue, Input, Select } from '@/components';
+import { IMAGE_DIC } from '../constants';
+
+const Wrap = styled.div`
+  display: flex;
+  gap: 8px;
+  margin-left: 4px;
+`;
+
+const CheckBoxHeadStyled = styled(CheckBox)`
+  & + label {
+    height: 18px;
+  }
+`;
+
+const CheckBoxStyled = styled(CheckBox)`
+  & + label {
+    height: 28px;
+  }
+`;
+
+const SelectStyled = styled(Select)`
+  height: 24px;
+
+  & .apro__control {
+    border: none;
+    padding: 0;
+    height: 24px;
+    min-height: 24px;
+
+    & .apro__value-container {
+      padding: 0;
+      height: 24px;
+      min-height: 24px;
+    }
+  }
+
+  & .apro__menu {
+    & > div > * {
+      padding-left: 2px;
+    }
+  }
+`;
+
+const InputStyled = styled(Input)`
+  & {
+    height: 24px;
+    padding: 4px;
+  }
+  border: none;
+  min-width: 24px;
+  border-color: transparent;
+`;
+
+const MOCK_OPTIONS = ['zoom', 'slack', 'notion', 'figma'].map((tool) => ({
+  label: (
+    <Wrap>
+      <img src={IMAGE_DIC[tool]} />
+      <span>{tool[0].toUpperCase() + tool.substring(1)}</span>
+    </Wrap>
+  ),
+  value: tool,
+}));
+
+interface UseMyAccountTableColumnsProps {
+  isAllSelected: boolean;
+  selectedRowIds: number[];
+  onRowChange: (row: Partial<AccountTableModel>) => void;
+  onSelectRows: () => void;
+  onSelectRow: (rowId: number) => void;
+}
+
+export const useMyAccountTableColumns = ({
+  isAllSelected,
+  selectedRowIds,
+  onRowChange,
+  onSelectRow,
+  onSelectRows,
+}: UseMyAccountTableColumnsProps): ColumnType<AccountTableModel>[] => {
+  const handleSelectRow = useCallback(
+    ({ id }: CheckedValue) => {
+      onSelectRow(Number(id));
+    },
+    [onSelectRow],
+  );
+
+  const handleSelectChangeCurried = useCallback(
+    (record: AccountTableModel) => (value: string) => {
+      if (!value.length) {
+        return;
+      }
+      onRowChange({ ...record, tools: value });
+    },
+    [onRowChange],
+  );
+
+  const handleInputChangeCurried = useCallback(
+    (record: AccountTableModel): ChangeEventHandler<HTMLInputElement> =>
+      (e) => {
+        onRowChange({ ...record, account: e.target.value });
+      },
+    [onRowChange],
+  );
+
+  const columns: ColumnType<AccountTableModel>[] = useMemo(() => {
+    return [
+      {
+        title: (
+          <CheckBoxHeadStyled
+            id="all"
+            onChange={onSelectRows}
+            checked={isAllSelected}
+          />
+        ),
+        dataIndex: 'id',
+        key: 'id',
+        render: (id: number) => (
+          <CheckBoxStyled
+            id={id.toString()}
+            onChange={handleSelectRow}
+            checked={selectedRowIds.includes(id)}
+          />
+        ),
+        width: 100,
+      },
+      {
+        title: '협업툴',
+        dataIndex: 'tools',
+        key: 'tools',
+        render: (tools, record) => {
+          if (record.editable) {
+            return (
+              <SelectStyled
+                // TODO: 변경
+                options={MOCK_OPTIONS}
+                value={tools}
+                onChange={handleSelectChangeCurried(record)}
+              />
+            );
+          }
+          return (
+            <Wrap>
+              <img src={IMAGE_DIC[tools]} />
+              <span>{tools[0].toUpperCase() + tools.substring(1)}</span>
+            </Wrap>
+          );
+        },
+        width: 400,
+      },
+      {
+        title: '계정',
+        dataIndex: 'account',
+        key: 'account',
+        render: (account: string, record) => {
+          if (record.editable) {
+            return (
+              <InputStyled
+                placeholder="계정 정보를 입력해 주세요."
+                onChange={handleInputChangeCurried(record)}
+              />
+            );
+          }
+          return account;
+        },
+      },
+    ];
+  }, [
+    handleInputChangeCurried,
+    handleSelectChangeCurried,
+    handleSelectRow,
+    isAllSelected,
+    onSelectRows,
+    selectedRowIds,
+  ]);
+
+  return columns;
+};

--- a/src/features/collaboration/models/account.models.ts
+++ b/src/features/collaboration/models/account.models.ts
@@ -17,6 +17,12 @@ export interface AccountTableModel {
    * 이후 변경 예정
    */
   account: string;
+  /**
+   * 수정 여부
+   *
+   * 추가 or 수정 시 변경된다.
+   */
+  editable?: boolean;
 }
 
 export interface PublicAccountTableModel extends AccountTableModel {

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -1,6 +1,5 @@
 import { createGlobalStyle } from 'styled-components';
 import reset from 'styled-reset';
-import 'rc-table/assets/index.css';
 
 export const GlobalStyle = createGlobalStyle`
 	${reset}


### PR DESCRIPTION
- Table css 커스텀
- prettierrc printWidth 설정 변경

## Updates <!-- 추가 되거나 바뀐 내용 -->

- rc-table을 피그마에 맞춰 css를 커스텀합니다.

## Others <!-- 기타 변경점들 (기능에 직접적인 연관이 없는 chore, style 등) -->

- prettier의 printwidth를 80으로 낮췄습니다. 이게 가독성이 더 좋더라구염
